### PR TITLE
Dl 1792 - remove unused feedback url

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -78,10 +78,6 @@ microservice {
         host = localhost
         port = 9250
       }
-      beta-feedback {
-        feedBackURL = "http://localhost:9514/feedback-survey/?origin=check-the-awrs-register"
-      }
-
       urBanner{
         external-urls{
           ur-page = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=AWRS_lookup&utm_source=Survey_Banner&utm_medium=other&t=HMRC&id=79"

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -11,9 +11,9 @@ private object AppDependencies {
   import play.core.PlayVersion
   import play.sbt.PlayImport._
 
-  private val frontendBootstrapVersion = "12.3.0"
-  private val playPartialsVersion = "6.5.0"
-  private val hmrcTestVersion = "3.4.0-play-25"
+  private val frontendBootstrapVersion = "12.6.0"
+  private val playPartialsVersion = "6.7.0-play-25"
+  private val hmrcTestVersion = "3.6.0-play-25"
   private val scalaTestVersion = "3.0.5"
   private val scalaTestPlusPlayVersion = "2.0.1"
   private val pegdownVersion = "1.6.0"


### PR DESCRIPTION
# DL-1792
**Bug fix**

Removed unused feedback url from applicatin.conf, as it was not referenced anywhere else in the code. This service is un-authed, so you cannot sign out which is the usual route to the feedback form.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
