### PR TITLE
Update search page to use the input component more closely inline...

### DIFF
--- a/app/views/lookup/search/search_core.scala.html
+++ b/app/views/lookup/search/search_core.scala.html
@@ -18,6 +18,7 @@
 @import views.html.helpers._
 @import views.html.lookup.search._
 @import views.html.main_template
+@import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.input.Input
@@ -49,9 +50,15 @@
             id = "query",
             name = "query",
             classes = "govuk-input--width-20",
-            hint = Hint(classes = "govuk-visually-hidden", content = HtmlContent(Messages("awrs.lookup.search.label")))
+            label = Label(
+              isPageHeading = true,
+              classes = "govuk-label--xl",
+              content = Text(Messages("awrs.lookup.search.heading"))
+            ),
+            hint = Hint(content = HtmlContent(Messages("awrs.lookup.search.lede", awrs_urn(), "")))
         ))
     </div>
+
 
     @button(Button(content = Text(Messages("awrs.generic.continue")), attributes = Map("id" -> "search")))
 }

--- a/app/views/lookup/search_main.scala.html
+++ b/app/views/lookup/search_main.scala.html
@@ -48,19 +48,8 @@
     @searchResult
 }
 
-@headers = {
-    @(searchTerm, searchResult) match {
-        case (Some(_), _) | (_, Some(_)) => {}
-        case _ => {
-            <h1 class="govuk-heading-xl" id="search-heading">@Messages("awrs.lookup.search.heading")</h1>
-            <p class="govuk-body" id="search-lede">@Html(Messages("awrs.lookup.search.lede", awrs_urn(), ""))</p>
-        }
-    }
-}
-
 @searchCore(
     searchForm = searchForm,
-    preFormContent = headers,
     postFormContent = results,
     action = action,
     title = searchTitle,

--- a/test/views/LookupViewTest.scala
+++ b/test/views/LookupViewTest.scala
@@ -53,9 +53,8 @@ class LookupViewTest extends AwrsUnitTestTraits with HtmlUtils {
       val document: Document = TestLookupController.show().apply(testRequest(query = None))
 
       document.title mustBe Messages("awrs.lookup.search.page_title")
-      document.getElementById("search-heading").text mustBe Messages("awrs.lookup.search.heading")
-      document.getElementById("search-lede").text must include(Messages("awrs.lookup.search.lede", Messages("awrs.lookup.search.awrs_urn","","","(","),")))
-      document.getElementById("search-lede").text must include(Messages("awrs.lookup.search.lede", Messages("awrs.lookup.search.awrs_urn","","","(","),")))
+      document.select("h1").text mustBe Messages("awrs.lookup.search.heading")
+      document.getElementById("query-hint").text must include(Messages("awrs.lookup.search.lede", Messages("awrs.lookup.search.awrs_urn","","","(","),")))
       document.getElementById("query").text mustBe ""
     }
 


### PR DESCRIPTION
How it should be used to improve accessibility.

The page was accessibility tests because the input was missing a label and the hint was incorrectly linked to the input using the wrong ID in the aria-describedby

All unit tests pass and the page passes axe accessibility tests